### PR TITLE
Add a Basic README + venv Bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Solo Trajectory Executor
+
+A ROS package for running trajectories on both the virutal and
+physical solo 8.
+
+A [setup script](https://gist.github.com/agupta231/37b058dcec2e08c89efe10b9323b9d23)
+is available to create a virutal environment with this ros package
+and all of our supporting packages for our as well.


### PR DESCRIPTION
Repo doesn't have a readme so added that. Also the venv setup script is done, but idk where to put that. Hosting it as a gist on my personal account till we can find a better spot for it. Included it in the readme for visibility.